### PR TITLE
chore: add 7-day package cooldowns (npm + Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       all-dependencies:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       all-dependencies:
         patterns:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age = 7


### PR DESCRIPTION
## Summary
- Adds `min-release-age = 7` to `.npmrc` — npm will not install package versions published less than 7 days ago (requires npm >= 11.10.0)
- Adds `cooldown` blocks to all Dependabot update entries — prevents PRs for packages published in the last 7 days
- Security updates are automatically exempt from the Dependabot cooldown

## Why
Reduces exposure to supply-chain attacks on freshly released package versions.
See https://cooldowns.dev for background.