### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to satisfy the `actions/missing-workflow-permissions` code scanning rule.

No functional change — the workflow previously relied on the repo's default token permissions.