### PR TITLE
docs: remove undeclared npx vite-bundle-visualizer command from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,3 @@ A collection of examples how common React patterns affect client side rendering.
 
 ## Development
 
-Analyze bundle size:
-
-```bash
- npx vite-bundle-visualizer -o stats.html --open
-```


### PR DESCRIPTION
Removes a manual bundle-analysis command that used npx to fetch vite-bundle-visualizer from the registry without a version pin. The tool is not declared as a devDependency and npx ignores min-release-age.